### PR TITLE
TreeNode should not have state

### DIFF
--- a/src/Vertica.Utilities.Tests/Collections/TreeTester.cs
+++ b/src/Vertica.Utilities.Tests/Collections/TreeTester.cs
@@ -254,5 +254,22 @@ namespace Vertica.Utilities.Tests.Collections
 			// c4 references a parent thats not there
 			Assert.That(tree.Count, Is.EqualTo(3));
 		}
+
+	    [Test]
+	    public void ChildCount_Should_Not_Have_State()
+	    {
+	        var categories = new[] { c1, c2, c3 };
+
+	        Tree<Category, int> tree = categories.ToTree(
+	            c => c.Id,
+	            (c, p) => c.ParentId.HasValue ? p.Value(c.ParentId.Value) : p.None);
+
+	        var treeNode = tree.Get(c1.Id);
+
+	        var childCountFirstTime = treeNode.ToArray().Length;
+	        var childCountSecondTime = treeNode.ToArray().Length;
+
+            Assert.That(childCountFirstTime, Is.EqualTo(childCountSecondTime));
+        }
     }
 }

--- a/src/Vertica.Utilities.Tests/Collections/TreeTester.cs
+++ b/src/Vertica.Utilities.Tests/Collections/TreeTester.cs
@@ -264,7 +264,7 @@ namespace Vertica.Utilities.Tests.Collections
 	            c => c.Id,
 	            (c, p) => c.ParentId.HasValue ? p.Value(c.ParentId.Value) : p.None);
 
-	        var treeNode = tree.Get(c1.Id);
+	        TreeNode<Category> treeNode = tree.Get(c1.Id);
 
 	        var childCountFirstTime = treeNode.ToArray().Length;
 	        var childCountSecondTime = treeNode.ToArray().Length;

--- a/src/Vertica.Utilities/Collections/Tree.cs
+++ b/src/Vertica.Utilities/Collections/Tree.cs
@@ -105,7 +105,7 @@ namespace Vertica.Utilities.Collections
 			{
 				node = new TreeNode<TModel>(
 					_tree[key].Model, 
-					GetEnumerator(item.Children),
+					() => GetEnumerator(item.Children),
  					index => Get(item.Children[index]),
 					item.Parents.Select(x => Get(x.Value)));
 			}
@@ -190,11 +190,11 @@ namespace Vertica.Utilities.Collections
 
 	public class TreeNode<TModel> : IEnumerable<TreeNode<TModel>>
 	{
-		private readonly IEnumerator<TreeNode<TModel>> _children;
+		private readonly Func<IEnumerator<TreeNode<TModel>>> _children;
 		private readonly Func<int, TreeNode<TModel>> _childNodeAt;
 		private readonly IEnumerable<TreeNode<TModel>> _parents;
 
-		internal TreeNode(TModel model, IEnumerator<TreeNode<TModel>> children, Func<int, TreeNode<TModel>> childNodeAt, IEnumerable<TreeNode<TModel>> parents)
+		internal TreeNode(TModel model, Func<IEnumerator<TreeNode<TModel>>> children, Func<int, TreeNode<TModel>> childNodeAt, IEnumerable<TreeNode<TModel>> parents)
 		{
 			Model = model;
 			_children = children;
@@ -214,7 +214,7 @@ namespace Vertica.Utilities.Collections
 
 		public IEnumerator<TreeNode<TModel>> GetEnumerator()
 		{
-			return _children;
+			return _children();
 		}
 
 	    public IEnumerable<TreeNode<TModel>> Parents


### PR DESCRIPTION
When iterating a treenode multiple times the number of childnodes changes.

Added failing unittest