### PR TITLE
Issue 49

### DIFF
--- a/src/Vertica.Utilities.Tests/OptionTester.cs
+++ b/src/Vertica.Utilities.Tests/OptionTester.cs
@@ -512,5 +512,64 @@ namespace Vertica.Utilities.Tests
 			Option<int> nullable = null;
 			Assert.That(()=>nullable.IsSome, Throws.InstanceOf<NullReferenceException>());
 		}
+		#region Do
+
+		[Test]
+		public void Do_Some_SomeActionIsPerformedWithValue()
+		{
+			int? value = null;
+			bool noneExecuted = false;
+
+			Option<int> subject = Option.Some(1);
+
+			subject.Do(
+				whenSome: (v) => value = v,
+				whenNone: (d) => noneExecuted = true);
+
+			Assert.That(value, Is.EqualTo(1));
+			Assert.That(noneExecuted, Is.False);
+		}
+
+		[Test]
+		public void Do_None_NoneActionIsPerformedWithDefault()
+		{
+			int? value = null;
+			bool someExecuted = false;
+
+			Option<int> subject = Option.None(1);
+
+			subject.Do(
+				whenSome: (v) => someExecuted = true,
+				whenNone: (d) => value = d);
+
+			Assert.That(value, Is.EqualTo(1));
+			Assert.That(someExecuted, Is.False);
+		}
+
+		[Test]
+		public void Do_SingleSome_ActionIsPerformedWithValue()
+		{
+			int? value = null;
+			
+			Option<int> subject = Option.Some(1);
+
+			subject.Do((v) => value = v);
+
+			Assert.That(value, Is.EqualTo(1));
+		}
+
+		[Test]
+		public void Do_SigleNone_ActionIsNotPerformed()
+		{
+			bool someExecuted = false;
+
+			Option<int> subject = Option.None(1);
+			
+			subject.Do((v) => someExecuted = true);
+
+			Assert.That(someExecuted, Is.False);
+		}
+
+		#endregion
 	}
 }

--- a/src/Vertica.Utilities.Tests/OptionTester.cs
+++ b/src/Vertica.Utilities.Tests/OptionTester.cs
@@ -60,6 +60,14 @@ namespace Vertica.Utilities.Tests
 			var missingCollection = Option.Maybe(new int[0]);
 			Assert.That(missingCollection.IsNone, Is.True);
 			Assert.That(missingCollection.ValueOrDefault, Is.Empty);
+
+			Option.Some(1).Do(v => Assert.That(v, Is.EqualTo(1)));
+			Option.Some(1).Do(
+				v => Assert.That(v, Is.EqualTo(1)),
+				d => throw new Exception("should not happen"));
+			Option.None(-1).Do(
+				whenSome: v => throw new Exception("should not happen"),
+				whenNone: d => Assert.That(d, Is.EqualTo(-1)));
 		}
 
 		#endregion

--- a/src/Vertica.Utilities/Option.cs
+++ b/src/Vertica.Utilities/Option.cs
@@ -86,5 +86,16 @@ namespace Vertica.Utilities
 
 			return EqualityComparer<T>.Default.GetHashCode(_value);
 		}
+
+		public void Do(Action<T> whenSome, Action<T> whenNone)
+		{
+			if(IsSome) whenSome(Value);
+			else whenNone(_default);
+		}
+
+		public void Do(Action<T> whenSome)
+		{
+			if(IsSome) whenSome(Value);
+		}
 	}
 }

--- a/src/Vertica.Utilities/Option.cs
+++ b/src/Vertica.Utilities/Option.cs
@@ -44,6 +44,11 @@ namespace Vertica.Utilities
 			return IsSome ? Value : defaultValue;
 		}
 
+		public T GetValueOrDefault(Func<T> defaultFactory)
+		{
+			return IsSome ? Value : defaultFactory();
+		}
+
 		private readonly T _value;
 		private bool _defaultChanged;
 		private T _default;
@@ -70,6 +75,7 @@ namespace Vertica.Utilities
 
 			return false;
 		}
+
 		public bool Equals(Option<T> other)
 		{
 			if (other == null) return false;
@@ -80,6 +86,7 @@ namespace Vertica.Utilities
 			}
 			return other.IsSome && EqualityComparer<T>.Default.Equals(_value, other._value);
 		}
+
 		public override int GetHashCode()
 		{
 			if (IsNone) return 0;


### PR DESCRIPTION
closes #49 

* Add `.Do()`to perform an operation depending on whether the option is some or none.
* Add `.GetValueOrDefault(factory)` for "expensive" default values
